### PR TITLE
Version 0.2

### DIFF
--- a/autowpdb-example-plugin.php
+++ b/autowpdb-example-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: AutoWPDB Example Plugin
  * Plugin URI: https://github.com/Screenfeed/autowpdb-example-plugin
  * Description: A plugin showing how to use Screenfeed/AutoWPDB.
- * Version: 0.1
+ * Version: 0.2
  * Requires PHP: 7.0
  * Author: Grégory Viguier
  * Author URI: https://www.screenfeed.fr/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "autowpdb-example-plugin",
 	"description": "A WordPress plugin showing how to use Screenfeed/AutoWPDB.",
-	"version": "0.1",
+	"version": "0.2.0",
 	"homepage": "https://github.com/Screenfeed/autowpdb-example-plugin",
 	"license": "GPL-2.0",
 	"private": true,

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: GregLone
 Requires at least: 4.9.6
 Tested up to: 5.4.2
-Stable tag: 0.1
+Stable tag: 0.2
 
 This is a WordPress plugin showing how to use [Screenfeed/AutoWPDB](https://github.com/Screenfeed/autowpdb).
 

--- a/src/CRUD.php
+++ b/src/CRUD.php
@@ -33,8 +33,8 @@ class CRUD extends Basic {
 	public function has_items(): bool {
 		global $wpdb;
 
-		$column     = esc_sql( $this->table->get_primary_key() );
-		$table_name = $this->table->get_table_name();
+		$column     = esc_sql( $this->get_table_definition()->get_primary_key() );
+		$table_name = $this->get_table_definition()->get_table_name();
 
 		return (bool) $wpdb->get_var( "SELECT $column FROM $table_name LIMIT 1;" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
@@ -50,7 +50,7 @@ class CRUD extends Basic {
 	public function get_item( int $prim_key_value ) { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoReturnType
 		$results = $this->get(
 			[ '*' ],
-			[ $this->table->get_primary_key() => $prim_key_value ]
+			[ $this->get_table_definition()->get_primary_key() => $prim_key_value ]
 		);
 
 		if ( empty( $results ) ) {
@@ -71,8 +71,8 @@ class CRUD extends Basic {
 	public function get_items( array $prim_key_values ) { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoReturnType
 		global $wpdb;
 
-		$table_name      = $this->table->get_table_name();
-		$where           = esc_sql( $this->table->get_primary_key() );
+		$table_name      = $this->get_table_definition()->get_table_name();
+		$where           = esc_sql( $this->get_table_definition()->get_primary_key() );
 		$prim_key_values = DBUtilities::prepare_values_list( $prim_key_values );
 
 		$results = $wpdb->get_results(
@@ -97,8 +97,8 @@ class CRUD extends Basic {
 	public function delete_oldest_item() { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoReturnType
 		global $wpdb;
 
-		$table_name = $this->table->get_table_name();
-		$where      = esc_sql( $this->table->get_primary_key() );
+		$table_name = $this->get_table_definition()->get_table_name();
+		$where      = esc_sql( $this->get_table_definition()->get_primary_key() );
 
 		$wpdb->check_current_query = false;
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Screenfeed\AutoWPDBExamplePlugin;
 
-use Screenfeed\AutoWPDB\TableDefinition\TableDefinitionInterface;
+use Screenfeed\AutoWPDB\Table;
 use Screenfeed\AutoWPDB\TableUpgrader;
 use stdClass;
 
@@ -31,9 +31,9 @@ class Plugin {
 	const POST_ACTION_ID = 'autowpdbexample_action';
 
 	/**
-	 * A TableDefinitionInterface object.
+	 * A Table object.
 	 *
-	 * @var   TableDefinitionInterface
+	 * @var   Table
 	 * @since 0.1
 	 */
 	protected $table;
@@ -62,7 +62,7 @@ class Plugin {
 	 * @return void
 	 */
 	public function init() {
-		$this->table    = new CustomTable();
+		$this->table    = new Table( new CustomTable() );
 		$this->upgrader = new TableUpgrader( $this->table );
 
 		$this->upgrader->init();
@@ -101,7 +101,7 @@ class Plugin {
 		}
 
 		// Get everything that is in the table.
-		$this->table_contents = ( new CRUD( $this->table ) )->get( [ '*' ], [], OBJECT_K );
+		$this->table_contents = ( new CRUD( $this->table->get_table_definition() ) )->get( [ '*' ], [], OBJECT_K );
 
 		// Page header.
 		$this->display_page_header();
@@ -132,7 +132,7 @@ class Plugin {
 				sprintf(
 					/* translators: 1 is the name of the DB table, 2 is an option name. */
 					__( 'Your custom table "%1$s" does not seem to be ready, something went wrong. Its current version number is maybe stored in the (network?) option "%2$s".', 'autowpdb-example-plugin' ),
-					$this->table->get_table_name(),
+					$this->table->get_table_definition()->get_table_name(),
 					$this->upgrader->get_db_version_option_name()
 				)
 			)
@@ -159,7 +159,7 @@ class Plugin {
 				sprintf(
 					/* translators: 1 is the name of the DB table, 2 is a version number, 3 is an option name. */
 					__( 'Your custom table "%1$s" is ready and its current version is %2$d. This version number is stored in the (network?) option "%3$s".', 'autowpdb-example-plugin' ),
-					$this->table->get_table_name(),
+					$this->table->get_table_definition()->get_table_name(),
 					$this->upgrader->get_db_version(),
 					$this->upgrader->get_db_version_option_name()
 				)
@@ -321,7 +321,7 @@ class Plugin {
 	 * @return int The new entry ID.
 	 */
 	public function action_insert_entry(): int {
-		return ( new CRUD( $this->table ) )->insert(
+		return ( new CRUD( $this->table->get_table_definition() ) )->insert(
 			[
 				'file_date' => date_i18n( 'Y-m-d H:i:s' ),
 				'path'      => '/foo/bar/' . wp_rand(),
@@ -343,7 +343,7 @@ class Plugin {
 	 * @return int The number of deleted entries.
 	 */
 	public function action_delete_entry(): int {
-		return (int) ( new CRUD( $this->table ) )->delete_oldest_item();
+		return (int) ( new CRUD( $this->table->get_table_definition() ) )->delete_oldest_item();
 	}
 
 	/** ----------------------------------------------------------------------------------------- */


### PR DESCRIPTION
Following changes from AutoWPDB v0.2:
- Class `CRUD`: use `get_table_definition()` instead of the property `table_definition`, which is private now.
- Class `Plugin`: use the new class `Table` instead of `CustomTable()` directly.